### PR TITLE
[WIP] use .ops domain

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		return
 	}
 
-	ip, err := nixopsHostIp(strings.TrimSuffix(q.Name, "."))
+	ip, err := nixopsHostIp(strings.TrimSuffix(q.Name, ".ops."))
 	if err != nil {
 		log.Println(err)
 		handleNotFound(w, r)
@@ -75,6 +75,8 @@ func handleNotFound(w dns.ResponseWriter, r *dns.Msg) {
 
 func main() {
 	var addr = flag.String("addr", "127.0.0.1:5300", "listen address")
+	// var domain = flag.String("domain", "ops", "fake domain name to strip from requests e.g. host.ops -> host")
+	// XXX: how to pass this to handleRequest, use ServeMux?
 
 	flag.Parse()
 


### PR DESCRIPTION
Hi,

I've managed to create a .nix build for this and add this to dnsmasq so I can use it along with other DNS servers except I had to add `.ops` domain for nixops hosts so I can match it in dnsmasq conf like this:

```nix
  services.dnsmasq = {
    enable = true;
    resolveLocalQueries = true;
    servers = [
      "/ops/127.0.0.1#5300"
    ];
    extraConfig = ''
      bind-interfaces
      listen-address=127.0.0.1
    '';
  };
```

The problem is I'm not proficient enough with Go to add this as a flag so I've just hacked this in `nixops-dns`. When this is solved I will create a PR for nixpkgs (probably with nixos module as well), what do you think?